### PR TITLE
Brute force but low memory compared to max(list)

### DIFF
--- a/problem_4.py
+++ b/problem_4.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+"""
+A palindromic number reads the same both ways. The largest palindrome made from
+the product of two 2-digit numbers is 9009 = 91 x 99.
+
+Find the largest palindrome made from the product of two 3-digit numbers.
+"""
+__author__ = "Dan Wagner"
+
+def is_palindrome(num):
+    forward = str(num)
+    backward = str(num)[::-1]
+    return forward == backward and str(num) != "0"
+
+rng = range(999, -1, -1)
+max_palindrome = 1
+for x in rng:
+    for y in rng:
+        if is_palindrome(x * y) and (x * y > max_palindrome):
+            max_palindrome = x * y
+
+print(max_palindrome)
+


### PR DESCRIPTION
Originally, I solved this with a list of palindromes, like:

``` python
# is_palindrome method
# ...

rng = range(999, -1, -1)
palindromes = []
for x in rng:
    for y in rng:
        if is_palindrome(x * y):
            palindromes.append(x * y)

print(max(palindromes))
```

but I think this is a better solution -- no point in storing ALL the palindromes when the max is all that matters.
